### PR TITLE
Add support for python 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "cython"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,10 +9,11 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
 project_urls =
     Source = https://github.com/cloudtools/sha256
     Tracker = https://github.com/cloudtools/sha256/issues

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,14 @@
 from setuptools import setup
-from setuptools.extension import Extension
-from setuptools.command.sdist import sdist as _sdist
-
-cmdclass = {}
-
-
-class sdist(_sdist):
-    def run(self):
-        from Cython.Build import cythonize
-        cythonize(['sha256.pyx'])
-        _sdist.run(self)
-cmdclass['sdist'] = sdist
+from Cython.Build import cythonize
 
 
 setup(
     name='sha256',
-    version='0.3',
+    version='1.0',
     description='sha256 library with midstate',
     author='Mark Peek',
     author_email='mark@peek.org',
     license="MIT",
-    cmdclass=cmdclass,
-    ext_modules=[Extension("sha256", ["sha256.c"])],
+    ext_modules=cythonize(['sha256.pyx']),
     test_suite="tests",
 )

--- a/sha256.pyx
+++ b/sha256.pyx
@@ -7,7 +7,7 @@ import struct
 
 from libc.stdint cimport uint64_t, uint32_t, uint8_t
 
-__version__ = "0.3"
+__version__ = "1.0"
 
 cdef uint32_t k[64]
 


### PR DESCRIPTION
The cython generated C code is different for 3.11 vs 3.10, so relying on pip using an sdist with that file included doesn't work. That is to say, that "pip install sha256" doesn't work on 3.11 with the 0.3 release on pypi.

This change updates setup.py to the current recommendation from cython (which removes the sdist step).  It adds a pyproject.toml so that cython is recognized as a build-time dependency in recent pip versions.  Package classifiers are updated to include 3.11. Finally the sha256 package version is updated to 0.4 to prepare for a future release.